### PR TITLE
feat: Add hysteresis to high humidity alert blueprint

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,20 @@
+## Description
+
+<!-- Décris brièvement le changement. -->
+
+## Schéma (optionnel)
+
+<!-- Ajoute un diagramme mermaid seulement si ça aide à comprendre le changement. -->
+
+<!--
+```mermaid
+graph TD
+  A --> B
+```
+-->
+
+
+---
+
+> [!NOTE]
+> Agents IA : restez très brefs. Une description claire et courte, un schéma mermaid seulement si utile.

--- a/automations.yaml
+++ b/automations.yaml
@@ -862,6 +862,7 @@
       - sensor.rm4_humidity
       - sensor.downstairs_motion_humidity
       - sensor.office_motion_humidity
+      - sensor.workshop_temperature_humidity_humidity
       threshold: 70
       for_duration:
         hours: 0
@@ -2721,15 +2722,6 @@
     target:
       entity_id: light.office
   mode: restart
-- id: '1775410987239'
-  alias: High humidity alert
-  description: ''
-  use_blueprint:
-    path: ericmatte/humidity_high_alert.yaml
-    input:
-      humidity_sensors:
-      - sensor.workshop_temperature_humidity_humidity
-      threshold: 90
 - id: '1776202142206'
   alias: Toggle covers
   description: ''

--- a/blueprints/automation/ericmatte/humidity_high_alert.yaml
+++ b/blueprints/automation/ericmatte/humidity_high_alert.yaml
@@ -3,7 +3,7 @@ blueprint:
   description: |
     Surveille un ou plusieurs capteurs d'humidité et envoie une notification quand la valeur dépasse un seuil de façon **soutenue**.
 
-    - 📈 **Déclencheur** : un capteur reste AU-DESSUS du seuil pendant la durée configurée.
+    - 📈 **Déclencheur** : un capteur reste AU-DESSUS du seuil + 5% pendant la durée configurée.
     - 🔔 **Action** : notification via `notify.notify` avec le nom de la pièce et la valeur courante.
     - 🔁 **Anti-spam** : la durée minimale empêche le déclenchement sur des oscillations brèves autour du seuil. Le trigger ne se réarme qu'après être redescendu sous le seuil.
   domain: automation
@@ -19,7 +19,7 @@ blueprint:
 
     threshold:
       name: 📊 Seuil d'humidité (%)
-      description: Déclenche la notification quand un capteur dépasse ce pourcentage.
+      description: Seuil accepté. La notification est envoyée seulement quand un capteur dépasse ce seuil de 5%.
       default: 70
       selector:
         number:
@@ -42,10 +42,12 @@ blueprint:
 
 variables:
   threshold_value: !input threshold
+  notification_threshold: "{{ threshold_value | float(0) + 5 }}"
 
 trigger:
   - platform: numeric_state
     entity_id: !input humidity_sensors
+    value_template: "{{ state.state | float(0) - 5 }}"
     above: !input threshold
     for: !input for_duration
 
@@ -56,6 +58,6 @@ action:
       message: >-
         {% set sensor = trigger.entity_id %}
         L'humidité dans la pièce '{{ area_name(sensor) }}' est à {{ states(sensor) }}%
-        (seuil accepté: {{ threshold_value }}%).
+        (seuil accepté: {{ threshold_value }}%, notification à partir de {{ notification_threshold }}%).
 
 mode: single


### PR DESCRIPTION
## Description

Ajoute une hystérésis de 5% au blueprint d'alerte de forte humidité pour éviter les notifications répétées quand la valeur oscille autour du seuil. Retire l'automation dédiée à l'atelier, dont le capteur est maintenant surveillé par l'alerte générale.

Ajoute aussi un template de PR concis (`.github/pull_request_template.md`).