### PR TITLE
refactor(blueprint): simplify summer mode to single setpoint + fan boost

### DIFF
--- a/automations.yaml
+++ b/automations.yaml
@@ -1084,9 +1084,7 @@
       use_target_from: 06:00:00
       fan_mode: auto
       summer_mode: input_boolean.climate_summer_mode
-      summer_target_temp: 21
-      pre_cool_start_time: '21:30:00'
-      bedtime: '22:30:00'
+      summer_target_temp: 20
       aux_summer_floor: 16
 - id: '1760485855717'
   alias: Light on when opening workshop door

--- a/blueprints/automation/ericmatte/smart_climate_controller.yaml
+++ b/blueprints/automation/ericmatte/smart_climate_controller.yaml
@@ -3,10 +3,10 @@ blueprint:
   description: |
     Orchestre une thermopompe et des thermostats auxiliaires (plinthes) à l'année, avec bascule hiver/été pilotée par un `input_boolean`.
 
-    - ⚡ **Déclencheur** : changement de présence, seuils de température extérieure, horaires clés (début/fin confort, pré-cool, coucher), ou bascule du mode été.
+    - ⚡ **Déclencheur** : changement de présence, seuils de température extérieure, horaires clés (début/fin confort hiver), changement de la température intérieure de la thermopompe (réactivité été), ou bascule du mode été.
     - 🎯 **Action hiver** : thermopompe sur consigne effective (confort si plage horaire + présence, sinon nuit/absence), auxiliaires à -2 °C en suiveur. Si extérieur < seuil minimum → thermopompe OFF et auxiliaires prennent le relais à +0,5 °C.
-    - 🎯 **Action été** : auxiliaires épinglés au plancher (jamais de chauffage), puis cooling dérivé d'une seule consigne été (pré-cool = cible -2, nuit = cible +2, jour = cible).
-    - 🚪 **Pré-cool** : entre l'heure d'ouverture et le coucher, la thermopompe descend sous la consigne été — laisser la porte de la chambre OUVERTE pour faire circuler l'air.
+    - 🎯 **Action été** : auxiliaires épinglés au plancher (jamais de chauffage), puis cooling sur une seule consigne été fixe.
+    - 💨 **Ventilateur boosté** : en été, si l'intérieur atteint la consigne été + 2 °C, le ventilateur passe à `high` (au lieu du mode configuré) le temps de rattraper le retard.
     - ✋ **Actions manuelles** : changer la consigne ou couper la thermopompe ne déclenche pas l'automation ; elle reprend seulement au prochain déclencheur prévu.
     - 🌀 **Anti-cycle court** : en été, si intérieur ≤ consigne − 1 °C → thermopompe OFF temporairement, évite les démarrages/arrêts rapprochés autour du setpoint intérieur.
     - ⏱️ **Anti-flicker seuil extérieur** : la température extérieure doit rester du même côté du seuil pendant 5 min avant de déclencher ON/OFF — pas d'oscillation quand la valeur frôle le seuil.
@@ -33,12 +33,12 @@ blueprint:
                          └─────────┘             ┌─┴─┐
                                                 OUI  NON
                                                  │    │
-                                            ┌────▼─┐ ┌▼──────────────────┐
-                                            │HP OFF│ │ fenêtre :         │
-                                            └──────┘ │  pré-cool / nuit  │
-                                                     │  / jour           │
-                                                     │ + anti-cycle court│
-                                                     └───────────────────┘
+                                            ┌────▼─┐ ┌▼─────────────────────┐
+                                            │HP OFF│ │ consigne = cible été │
+                                            └──────┘ │ + anti-cycle court   │
+                                                     │ + boost ventilo      │
+                                                     │   si int ≥ +2 °C     │
+                                                     └───────────────────────┘
     ```
 
   domain: automation
@@ -72,13 +72,6 @@ blueprint:
       selector:
         entity:
           domain: binary_sensor
-
-    use_target_from:
-      name: 🕒 Début de la plage "confort"
-      description: Heure à laquelle la consigne de confort devient active (hiver) et où la nuit se termine (été).
-      default: "07:00"
-      selector:
-        time:
 
     fan_mode:
       name: 🌀 Mode du ventilateur
@@ -139,6 +132,13 @@ blueprint:
           unit_of_measurement: "°C"
           mode: slider
 
+    use_target_from:
+      name: ❄️ Début de la plage "confort"
+      description: Heure à laquelle la consigne de confort devient active (hiver).
+      default: "07:00"
+      selector:
+        time:
+
     use_target_until:
       name: ❄️ Fin de la plage "confort"
       description: Heure à laquelle la consigne nuit/absence devient active en hiver.
@@ -150,31 +150,13 @@ blueprint:
     summer_target_temp:
       name: ☀️ Température cible
       description: Température cible en été. Sert aussi de seuil extérieur pour activer la climatisation.
-      default: 23
+      default: 20
       selector:
         number:
           min: 18
           max: 28
           unit_of_measurement: "°C"
           mode: slider
-
-    pre_cool_start_time:
-      name: ☀️ Heure d'ouverture de la fenêtre de pré-cool
-      description: >
-        Heure à laquelle la thermopompe passe à la consigne été -2 °C
-        (et y reste jusqu'à l'heure du coucher).
-      default: "21:30"
-      selector:
-        time:
-
-    bedtime:
-      name: ☀️ Heure du coucher
-      description: >
-        Heure approximative à laquelle tu vas te coucher. Ferme la fenêtre
-        de pré-cool et marque le début du mode nuit.
-      default: "22:30"
-      selector:
-        time:
 
     aux_summer_floor:
       name: ☀️ Plancher des thermostats auxiliaires
@@ -229,13 +211,16 @@ trigger:
     for:
       minutes: 5
 
-  - platform: time
-    at: !input pre_cool_start_time
-    id: pre_cool_eval
-
-  - platform: time
-    at: !input bedtime
-    id: bedtime_eval
+  # Réactivité été : current_temperature est un attribut d'état de la thermopompe —
+  # ce trigger capte ses variations pour réagir vite au boost ventilateur.
+  # Scope volontairement limité à cet attribut (pas platform: state générique) pour
+  # éviter que les propres appels climate.set_temperature / climate.set_fan_mode de
+  # cette automation (qui touchent 'temperature' et 'fan_mode', pas 'current_temperature')
+  # ne se re-déclenchent eux-mêmes. Inoffensif en hiver (branche hiver n'utilise pas
+  # inside_temp).
+  - platform: state
+    entity_id: !input heat_pump
+    attribute: current_temperature
 
 variables:
   heat_pump: !input heat_pump
@@ -252,12 +237,8 @@ variables:
   # Summer (mostly derived from summer_target_temp to keep inputs minimal)
   summer_mode: !input summer_mode
   summer_target_temp: !input summer_target_temp
-  summer_pre_cool_setpoint: "{{ (summer_target_temp | float) - 2 }}"
-  summer_night_setpoint: "{{ (summer_target_temp | float) + 2 }}"
-  summer_cool_threshold: "{{ summer_target_temp | float }}"
+  summer_fan_boost_threshold: "{{ (summer_target_temp | float) + 2 }}"
   cool_off_margin: 1
-  pre_cool_start_time: !input pre_cool_start_time
-  bedtime: !input bedtime
   aux_summer_floor: !input aux_summer_floor
   # Determine which target temperature to use (winter)
   effective_target_temp: >
@@ -283,7 +264,7 @@ action:
           - variables:
               inside_temp: "{{ state_attr(heat_pump, 'current_temperature') | float(0) }}"
               is_home: "{{ is_state(anybody_home, 'on') }}"
-              outside_too_cool: "{{ outside_temp < (summer_cool_threshold | float) }}"
+              outside_too_cool: "{{ outside_temp < (summer_target_temp | float) }}"
 
           # Aux thermostats : pin au floor en mode été (jamais de chauffage)
           - service: climate.set_temperature
@@ -313,24 +294,11 @@ action:
 
             # ----- DEFAULT : cooling actif -----
             default:
-              - variables:
-                  now_hm: "{{ now().strftime('%H:%M:%S') }}"
-                  in_pre_cool_window: "{{ pre_cool_start_time <= now_hm < bedtime }}"
-                  is_night: "{{ now_hm >= bedtime or now_hm < use_target_from }}"
-                  summer_setpoint: >
-                    {% if in_pre_cool_window %}
-                      {{ summer_pre_cool_setpoint }}
-                    {% elif is_night %}
-                      {{ summer_night_setpoint }}
-                    {% else %}
-                      {{ summer_target_temp }}
-                    {% endif %}
-
               - choose:
                   # Intérieur déjà assez froid → off (marge anti-cycle)
                   - conditions:
                       - condition: template
-                        value_template: "{{ inside_temp <= (summer_setpoint | float - cool_off_margin) }}"
+                        value_template: "{{ inside_temp <= (summer_target_temp | float - cool_off_margin) }}"
                     sequence:
                       - service: climate.turn_off
                         target:
@@ -340,18 +308,22 @@ action:
                     target:
                       entity_id: "{{ heat_pump }}"
                     data:
-                      temperature: "{{ summer_setpoint }}"
+                      temperature: "{{ summer_target_temp }}"
                       hvac_mode: cool
+
+                  # Boost ventilo si l'intérieur traîne loin au-dessus de la cible
+                  - variables:
+                      summer_fan_target: "{{ 'high' if inside_temp >= (summer_fan_boost_threshold | float) else fan_mode }}"
 
                   - delay:
                       seconds: 2
                   - condition: template
-                    value_template: "{{ state_attr(heat_pump, 'fan_mode') != fan_mode }}"
+                    value_template: "{{ state_attr(heat_pump, 'fan_mode') != summer_fan_target }}"
                   - service: climate.set_fan_mode
                     target:
                       entity_id: "{{ heat_pump }}"
                     data:
-                      fan_mode: "{{ fan_mode }}"
+                      fan_mode: "{{ summer_fan_target }}"
 
       # ===================== WINTER MODE (logique originale, intacte) =====================
       - conditions:

--- a/www/atrium/validation-checklists.json
+++ b/www/atrium/validation-checklists.json
@@ -10,6 +10,22 @@
       {
         "id": "no-manual-override-block",
         "text": "✋ Un climate.turn_off ou un changement de consigne fait à la main ne bloque plus l'automation jusqu'à minuit — elle reprend au prochain déclencheur prévu"
+      },
+      {
+        "id": "summer-single-setpoint",
+        "text": "🎯 La climatisation été utilise une seule consigne (summer_target_temp) — plus de variantes pré-cool/nuit/jour, et les inputs pre_cool_start_time / bedtime ont disparu"
+      },
+      {
+        "id": "fan-boost-high",
+        "text": "💨 Intérieur ≥ summer_target_temp + 2°C en été → le ventilateur de la thermopompe passe à high (au lieu du mode configuré), puis revient au mode configuré une fois redescendu"
+      },
+      {
+        "id": "heat-pump-trigger-responsive",
+        "text": "🌀 Un changement de current_temperature sur la thermopompe redéclenche bien l'automation rapidement, sans boucle de re-déclenchements causée par les propres actions de l'automation"
+      },
+      {
+        "id": "use-target-from-winter-only",
+        "text": "❄️ use_target_from ne pilote plus que la plage confort hiver — son déplacement dans la section hiver des inputs n'a rien changé au comportement réel"
       }
     ],
     "ongoing": [
@@ -18,8 +34,8 @@
         "text": "🥵 Journée chaude : la climatisation démarre quand l'extérieur atteint summer_target_temp"
       },
       {
-        "id": "summer-night-setpoint",
-        "text": "🌙 Nuit d'été : la consigne nuit (cible +2°C) s'applique correctement entre le coucher et le début de la plage confort"
+        "id": "fan-boost-hot-day",
+        "text": "💨 Journée très chaude : le ventilateur de la thermopompe passe à high quand l'intérieur dépasse summer_target_temp + 2°C, puis revient au mode configuré une fois la cible atteinte"
       },
       {
         "id": "manual-change-recovers",


### PR DESCRIPTION
## Description

Simplifie le mode été du contrôleur climatique intelligent : une seule consigne fixe (`summer_target_temp`, 20°C) remplace les variantes pré-cool/nuit/jour (inputs `pre_cool_start_time`/`bedtime` supprimés). Ajoute un boost du ventilateur à `high` quand l'intérieur dépasse la cible + 2°C, avec un nouveau trigger réactif sur la température intérieure de la thermopompe. `use_target_from` déplacé dans la section hiver puisqu'il ne sert plus qu'à ce mode. Le mode hiver n'est pas touché. Checklist de validation Atrium mise à jour en conséquence.

## Schéma (optionnel)